### PR TITLE
Temporary fix for double onActivityResult call

### DIFF
--- a/android/src/main/java/com/deligence/braintree_payment/BraintreePaymentPlugin.java
+++ b/android/src/main/java/com/deligence/braintree_payment/BraintreePaymentPlugin.java
@@ -93,6 +93,7 @@ public class BraintreePaymentPlugin implements MethodCallHandler, ActivityResult
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data)  {
+      if(activeResult == null) {return;}
         switch (requestCode) {
             case REQUEST_CODE:
                 if (resultCode == Activity.RESULT_OK) {

--- a/android/src/main/java/com/deligence/braintree_payment/BraintreePaymentPlugin.java
+++ b/android/src/main/java/com/deligence/braintree_payment/BraintreePaymentPlugin.java
@@ -93,7 +93,7 @@ public class BraintreePaymentPlugin implements MethodCallHandler, ActivityResult
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data)  {
-      if(activeResult == null) {return;}
+      if(activeResult == null) {return true;}
         switch (requestCode) {
             case REQUEST_CODE:
                 if (resultCode == Activity.RESULT_OK) {


### PR DESCRIPTION
On the second call, activeResult was null.